### PR TITLE
[PR] 프로젝트 목록 조회/생성 UI, 기능 구현

### DIFF
--- a/src/examples/Sidenav/SidenavCreateProjectModal.vue
+++ b/src/examples/Sidenav/SidenavCreateProjectModal.vue
@@ -86,9 +86,10 @@
 </template>
 
 <script>
-import {authInstance, defaultInstance} from "@/axios/axios-instance";
+import {defaultInstance} from "@/axios/axios-instance";
 import MaterialButton from "@/components/MaterialButton.vue";
 import MaterialInput from "@/components/MaterialInput.vue";
+import store from "@/store";
 // import router from "@/router";
 
 export default {
@@ -104,8 +105,8 @@ export default {
     async open() {
       this.isActive = true;
       try {
-        let employeeId = "EP001";
-        const response = await authInstance.get(`projects/list/${employeeId}`);
+        const employeeId = store.getters.employeeId;
+        const response = await defaultInstance.get(`projects/list/${employeeId}`);
         this.projects = response.data.result.viewProjectList;
       } catch (error) {
         console.error('Error fetching projects:', error);
@@ -127,11 +128,13 @@ export default {
         projectEndDate: '',
         projectStatus: '계획',
         projectModifiedDate: '',
+        employeeId: store.getters.employeeId,  // 임시로 EP001로 설정
         isNew: true,
       });
     },
     async saveProject() {
       try {
+        console.log('Saving project:', this.projects[0])
         await defaultInstance.post(`projects/create`, this.projects[0]);
         this.projects[0].isNew = false;
         this.isEditing = false;

--- a/src/examples/Sidenav/SidenavCreateProjectModal.vue
+++ b/src/examples/Sidenav/SidenavCreateProjectModal.vue
@@ -19,9 +19,36 @@
           <tbody>
           <tr v-for="project in projects" :key="project.projectId">
             <td>{{ project.projectId }}</td>
-            <td>{{ project.projectTitle }}</td>
-            <td>{{ project.projectStartDate }}</td>
-            <td>{{ project.projectEndDate }}</td>
+            <td>
+              <material-input
+                  v-if="project.isNew"
+                  v-model="project.projectTitle"
+                  class="w-90"
+                  label="제목"
+                  required
+              ></material-input>
+              <span v-else>{{ project.projectTitle }}</span>
+            </td>
+            <td>
+              <material-input
+                  v-if="project.isNew"
+                  v-model="project.projectStartDate"
+                  class="w-90"
+                  type="date"
+                  required
+              ></material-input>
+              <span v-else>{{ project.projectStartDate }}</span>
+            </td>
+            <td>
+              <material-input
+                  v-if="project.isNew"
+                  v-model="project.projectEndDate"
+                  class="w-90"
+                  type="date"
+                  required
+              ></material-input>
+              <span v-else>{{ project.projectEndDate }}</span>
+            </td>
             <td>{{ project.projectStatus }}</td>
             <td>{{ project.projectModifiedDate }}</td>
           </tr>
@@ -29,18 +56,28 @@
         </table>
       </div>
       <div class="mx-3">
-        <button
-            class="btn mt-4 w-25"
-            @click="create"
-            :class="`bg-gradient-${this.$store.state.color}`"
-        >생성
-        </button>
-        <button
-            class="btn mt-4 w-25"
+        <div v-if="isEditing">
+          <material-button
+              class="mt-4 w-25"
+              @click="saveProject"
+              :class="`bg-gradient-${this.$store.state.color}`"
+          >저장
+          </material-button>
+        </div>
+        <div v-else>
+          <material-button
+              class="mt-4 w-25"
+              @click="create"
+              :class="`bg-gradient-${this.$store.state.color}`"
+          >추가
+          </material-button>
+        </div>
+        <material-button
+            class="mt-4 w-25"
+            color="cancel"
             @click="close"
-
-        >취소
-        </button>
+        >닫기
+        </material-button>
       </div>
     </div>
   </div>
@@ -49,13 +86,18 @@
 </template>
 
 <script>
-import axios from "axios";
+import {authInstance} from "@/axios/axios-instance";
+import MaterialButton from "@/components/MaterialButton.vue";
+import MaterialInput from "@/components/MaterialInput.vue";
+// import router from "@/router";
 
 export default {
+  components: {MaterialButton, MaterialInput},
   data() {
     return {
       isActive: false,
       projects: [],
+      isEditing: false,
     };
   },
   methods: {
@@ -63,7 +105,7 @@ export default {
       this.isActive = true;
       try {
         let employeeId = "EP001";
-        const response = await axios.get(`http://localhost:8888/projects/list/${employeeId}`);
+        const response = await authInstance.get(`projects/list/${employeeId}`);
         this.projects = response.data.result.viewProjectList;
       } catch (error) {
         console.error('Error fetching projects:', error);
@@ -71,10 +113,26 @@ export default {
     },
     close() {
       this.isActive = false;
+      this.isEditing = false;
+    },
+    selectProject(project) {
+      console.log(`Selected project ID: ㅊ${project.projectId}`);
     },
     create() {
-      // 프로젝트 생성 로직을 추가하세요.
-      this.close();
+      this.isEditing = true;
+      this.projects.unshift({
+        projectId: '',
+        projectTitle: '',
+        projectStartDate: '',
+        projectEndDate: '',
+        isNew: true,
+      });
+    },
+    saveProject() {
+      // 여기에 프로젝트 저장 로직을 추가하세요.
+      console.log(`Saving project: ${this.projects[0].projectTitle}`);
+      this.projects[0].isNew = false;
+      this.isEditing = false;
     },
   },
 };
@@ -125,13 +183,11 @@ export default {
 }
 
 .btn.mt-4:nth-child(1) {
-  left: 25%;
-  transform: translate(-25%, -50%);
+  left: 20%;
 }
 
 .btn.mt-4:nth-child(2) {
-  left: 75%;
-  transform: translate(-75%, -50%);
+  left: 55%;
   background-color: gray;
   color: white;
 }
@@ -139,5 +195,6 @@ export default {
 tr,
 td {
   text-align: center;
+  vertical-align: middle;
 }
 </style>

--- a/src/examples/Sidenav/SidenavCreateProjectModal.vue
+++ b/src/examples/Sidenav/SidenavCreateProjectModal.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script>
-import {authInstance} from "@/axios/axios-instance";
+import {authInstance, defaultInstance} from "@/axios/axios-instance";
 import MaterialButton from "@/components/MaterialButton.vue";
 import MaterialInput from "@/components/MaterialInput.vue";
 // import router from "@/router";
@@ -116,7 +116,7 @@ export default {
       this.isEditing = false;
     },
     selectProject(project) {
-      console.log(`Selected project ID: ㅊ${project.projectId}`);
+      console.log(`Selected project ID: ${project.projectId}`);
     },
     create() {
       this.isEditing = true;
@@ -125,14 +125,20 @@ export default {
         projectTitle: '',
         projectStartDate: '',
         projectEndDate: '',
+        projectStatus: '계획',
+        projectModifiedDate: '',
         isNew: true,
       });
     },
-    saveProject() {
-      // 여기에 프로젝트 저장 로직을 추가하세요.
-      console.log(`Saving project: ${this.projects[0].projectTitle}`);
-      this.projects[0].isNew = false;
-      this.isEditing = false;
+    async saveProject() {
+      try {
+        await defaultInstance.post(`projects/create`, this.projects[0]);
+        this.projects[0].isNew = false;
+        this.isEditing = false;
+        await this.open();
+      } catch (error) {
+        console.error('Error creating projects:', error);
+      }
     },
   },
 };

--- a/src/examples/Sidenav/SidenavList.vue
+++ b/src/examples/Sidenav/SidenavList.vue
@@ -125,7 +125,7 @@
     <div class="sidenav-footer position-absolute w-100 bottom-0">
       <div class="mx-3">
         <a
-          class="btn mt-4 w-100"
+          class="btn w-100 "
           :class="`bg-gradient-${this.$store.state.color}`"
           @click="openCreateProjectModal"
           >프로젝트 목록</a

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -11,9 +11,10 @@ export async function login(employeeId, password) {
     });
 
     if (response.status === 200) {  // 로그인 성공 시 처리
-        store.commit("needLogin", false);                         // 로그인 필요 여부 변경
+        store.commit("needLogin", false);                       // 로그인 필요 여부 변경
         store.commit('accessToken', response.headers["accesstoken"]);   // accessToken 저장
-        store.commit("employeeId", response.headers["employeeId"]);     // 사원번호 저장
+        store.commit("employeeId", response.headers["employeeid"]);     // 회원ID 저장
+        store.commit("employeeName", response.headers["employeename"]); // 이름 저장
     }
 }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -22,6 +22,7 @@ export default createStore({
     // 로그인 관련
     needLogin: true,
     employeeId: "",
+    employeeName: "",
     accessToken: localStorage.getItem("accessToken") || null,
   },
   mutations: {
@@ -63,6 +64,9 @@ export default createStore({
     employeeId(state, data) {
       state.employeeId = data;
     },
+    employeeName(state, data) {
+      state.employeeName = data;
+    },
     accessToken(state, data) {
       state.accessToken = data;
       localStorage.setItem('accessToken', data);
@@ -79,6 +83,9 @@ export default createStore({
     },
     employeeId(state) {
       return state.employeeId;
+    },
+    employeeName(state) {
+      return state.employeeName;
     },
   },
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

- #9 

## 📝작업 내용

#### store(Vuex 저장소)
- **서버에 요청을 보낼 때나 화면 구현 시 `회원ID(employeeId)`와 `회원이름(employeeName)`이 자주 사용되고 필요하여 store로 저장하여 언제든 사용할 수 있게 로그인 요청 시 받아오게 수정함**

#### 프로젝트 목록
- modal로 볼 수 있게 SideNav에 사용하지 않는 버튼을 수정
- 사용자가 **구성원으로 속해있는 프로젝트**의 목록만 조회 가능 (ID 기준 내림차순)

#### 프로젝트 생성
- `추가` 버튼을 누르게 되면 목록 가장 위에 입력창이 뜨면서 **'제목', '시작일', '마감일'**을 입력할 수 있게 됨
- 새로 생성되는 **프로젝트의 상태**는 **'계획'**으로 고정
- '저장' 버튼을 누르게 되면 프로젝트를 저장하고 새로 부여 받은 ID와 '마지막 수정 날짜'가 함께 보이게 됨

#### 프로젝트 선택
- 이 기능은 논의가 필요할 것으로 보여 아직 구현하지 못했음(**익일 회의를 거쳐 정할 생각**)

### 📷스크린샷 (선택)

#### 프로젝트 목록 버튼
![image](https://github.com/OmokNoonE/PPM-frontend/assets/64572078/025cb206-7bfd-4dbf-ba72-c64523220ad0)

#### 프로젝트 목록 보기
![image](https://github.com/OmokNoonE/PPM-frontend/assets/64572078/b5da0bc3-43f8-4f99-b2db-f8a67aac9bb4)

#### 프로젝트 추가
![image](https://github.com/OmokNoonE/PPM-frontend/assets/64572078/7acdc253-2e4a-41d4-be0e-d21d229c309b)


## 💬리뷰 요구사항(선택)

> 디자인적으로나 더 보여줬으면 하는 정보가 있으면 말씀해주세요~
