### PR TITLE
#36 [fix] 사이드바 네이비게이션 라우터 경로 수정

### DIFF
--- a/src/examples/Sidenav/SidenavList.vue
+++ b/src/examples/Sidenav/SidenavList.vue
@@ -10,7 +10,7 @@
           :aria-controls="''"
           v-bind:collapse="false"
           collapseRef="dashboard"
-          navText="Dashboard"
+          navText="대시보드"
         >
           <template v-slot:icon>
             <i class="material-icons-round opacity-10 fs-5">dashboard</i>
@@ -22,11 +22,11 @@
           url="#"
           :aria-controls="''"
           v-bind:collapse="false"
-          collapseRef="tables"
-          navText="Tables"
+          collapseRef="project-member"
+          navText="프로젝트 구성원"
         >
           <template v-slot:icon>
-            <i class="material-icons-round opacity-10 fs-5">table_view</i>
+            <i class="material-icons-round opacity-10 fs-5">groups</i>
           </template>
         </sidenav-collapse>
       </li>
@@ -36,7 +36,20 @@
           :aria-controls="''"
           v-bind:collapse="false"
           collapseRef="billing"
-          navText="Billing"
+          navText="일정"
+        >
+          <template v-slot:icon>
+            <i class="material-icons-round opacity-10 fs-5">table_view</i>
+          </template>
+        </sidenav-collapse>
+      </li>
+      <li class="nav-item">
+        <sidenav-collapse
+            url="#"
+            :aria-controls="''"
+            v-bind:collapse="false"
+            collapseRef="requirements"
+            navText="요구사항"
         >
           <template v-slot:icon>
             <i class="material-icons-round opacity-10 fs-5">receipt_long</i>
@@ -48,23 +61,8 @@
           url="#"
           :aria-controls="''"
           v-bind:collapse="false"
-          collapseRef="rtl-page"
-          navText="Rtl"
-        >
-          <template v-slot:icon>
-            <i class="material-icons-round opacity-10 fs-5"
-              >format_textdirection_r_to_l</i
-            >
-          </template>
-        </sidenav-collapse>
-      </li>
-      <li class="nav-item">
-        <sidenav-collapse
-          url="#"
-          :aria-controls="''"
-          v-bind:collapse="false"
           collapseRef="notifications"
-          navText="Notifications"
+          navText="알림"
         >
           <template v-slot:icon>
             <i class="material-icons-round opacity-10 fs-5">notifications</i>
@@ -118,19 +116,6 @@
         >
           <template v-slot:icon>
             <i class="material-icons-round opacity-10 fs-5">logout</i>
-          </template>
-        </sidenav-collapse>
-      </li>
-      <li class="nav-item">
-        <sidenav-collapse
-            url="#"
-            :aria-controls="''"
-            v-bind:collapse="false"
-            collapseRef="requirements/list"
-            navText="Requirements"
-        >
-          <template v-slot:icon>
-            <i class="material-icons-round opacity-10 fs-5">table_view</i>
           </template>
         </sidenav-collapse>
       </li>

--- a/src/examples/Sidenav/index.vue
+++ b/src/examples/Sidenav/index.vue
@@ -24,7 +24,7 @@
           alt="main_logo"
         />
         <span class="ms-2 font-weight-bold text-white"
-          >Material Dashboard 2</span
+          >PPM</span
         >
       </a>
     </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,22 +20,22 @@ const routes = [
   },
   {
     path: "/dashboard",
-    name: "Dashboard",
+    name: "대시보드",
     component: Dashboard,
   },
   {
     path: "/project-member",
-    name: "ProjectMember",
+    name: "프로젝트 구성원",
     component: ProjectMember,
   },
   {
     path: "/billing",
-    name: "Billing",
+    name: "일정",
     component: Billing,
   },
   {
     path: "/notifications",
-    name: "Notifications",
+    name: "알림",
     component: Notifications,
   },
   {
@@ -45,7 +45,7 @@ const routes = [
   },
   {
     path: "/requirements",
-    name: "Requirements",
+    name: "요구사항",
     component: Requirements,
   },
   {


### PR DESCRIPTION
변경된 router index.js의 경로를 맞추기 위해서 SidenavList.vue의 collapseRef를 수정하였습니다. (영문 표현은 한글로 변경하였습니다.)

## #️⃣연관된 이슈

- #36 

## 📝작업 내용

> 사이드바 네이비게이션 라우터 경로 수정

### 📷스크린샷 (선택)
![image](https://github.com/OmokNoonE/PPM-frontend/assets/152199695/0c1e8a26-75b6-40ce-8d15-8232231e483f)
