### PR TITLE
[PR] 일정 2차 QA 및 수정

### DIFF
--- a/src/components/MaterialSchedule.vue
+++ b/src/components/MaterialSchedule.vue
@@ -101,6 +101,9 @@
                 </select>
               </div>
               <span v-else class="modal-info-value">
+                <span v-if="schedule.status === 10301" class="status-circle status-pending"></span>
+                <span v-else-if="schedule.status === 10302" class="status-circle status-in-progress"></span>
+                <span v-else-if="schedule.status === 10303" class="status-circle status-completed"></span>
                 {{
                   schedule.status === 10303 ? '완료' :
                       schedule.status === 10302 ? '진행' : '준비'
@@ -1457,6 +1460,25 @@ export default {
   min-height: 100px;
   padding: 0.5rem;
   width: 100%;
+}
+
+.status-circle {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.status-in-progress {
+  background-color: #f0ad4e; /* 진행중 상태의 색상 */
+}
+
+.status-completed {
+  background-color: #5cb85c; /* 완료 상태의 색상 */
+}
+
+.status-pending {
+  background-color: #d9534f; /* 보류중 상태의 색상 */
 }
 
 @keyframes fadeOut {

--- a/src/components/MaterialSchedule.vue
+++ b/src/components/MaterialSchedule.vue
@@ -897,6 +897,10 @@ export default {
           this.reason)) {
         this.toast.warning('* 표시된 항목을 채워주세요.')
       } else {
+        if ( this.schedule.startDate  > this.schedule.endDate){
+          this.toast.error('시작일이 종료일보다 늦습니다.');
+          return;
+        }
         try {
           const response = await defaultInstance.put(`/schedules/modify/${this.scheduleId}`, {
             scheduleId: this.scheduleId,

--- a/src/components/MaterialSchedule.vue
+++ b/src/components/MaterialSchedule.vue
@@ -490,7 +490,7 @@
               <th>내용</th>
             </tr>
             </thead>
-            <tbody>
+            <tbody v-if="searchSchedules.length > 0">
             <tr v-for="(schedule, id) in searchSchedules" :key="id">
               <td>{{ schedule.id }}</td>
               <td>{{ schedule.title }}</td>
@@ -499,6 +499,11 @@
                 <MaterialButton variant="fill" color="info" @click="selectSchedule(schedule)">선택
                 </MaterialButton>
               </td>
+            </tr>
+            </tbody>
+            <tbody v-else>
+            <tr>
+              <td colspan="3">검색 결과가 없습니다.</td>
             </tr>
             </tbody>
           </table>
@@ -544,12 +549,12 @@ export default {
         projectName: '',
       },
       searchSchedules: [
-        {
-          id: null,
-          title: '',
-          content: '',
-          type: '',
-        }
+        // {
+        //   id: null,
+        //   title: '',
+        //   content: '',
+        //   type: '',
+        // }
       ],
       tasks: [
         // {
@@ -667,21 +672,36 @@ export default {
       return dayDiff >= 0 ? dayDiff : '유효하지 않은 날짜';
     },
 
-    openSearchScheduleModal(type) {
+    async openSearchScheduleModal(type) {
       this.isSearchModal = true;
       this.searchScheduleType = type;
+      await this.searchSchedule();
     },
     async searchSchedule() {
-      try {
-        const response = await defaultInstance.get(`/schedules/search/${this.searchScheduleTitleValue}/${this.projectId}`);
-        const data = response.data.result.searchScheduleByTitle;
-        this.searchSchedules = data.map(schedule => ({
-          id: schedule.scheduleId,
-          title: schedule.scheduleTitle,
-          content: schedule.scheduleContent,
-        }));
-      } catch (error) {
-        console.log(error);
+      if (!this.searchScheduleTitleValue) {
+        try {
+          const response = await defaultInstance.get(`/schedules/list/${this.projectId}`);
+          const data = response.data.result.viewScheduleByProject;
+          this.searchSchedules = data.map(schedule => ({
+            id: schedule.scheduleId,
+            title: schedule.scheduleTitle,
+            content: schedule.scheduleContent,
+          }));
+        } catch (error) {
+          console.log(error);
+        }
+      } else {
+        try {
+          const response = await defaultInstance.get(`/schedules/search/${this.searchScheduleTitleValue}/${this.projectId}`);
+          const data = response.data.result.searchScheduleByTitle;
+          this.searchSchedules = data.map(schedule => ({
+            id: schedule.scheduleId,
+            title: schedule.scheduleTitle,
+            content: schedule.scheduleContent,
+          }));
+        } catch (error) {
+          console.log(error);
+        }
       }
     },
     setSelectedScheduleRequestBody(){

--- a/src/components/MaterialSchedule.vue
+++ b/src/components/MaterialSchedule.vue
@@ -752,18 +752,17 @@ export default {
         const requestBody = {
           stakeholdersType: 10402,
           stakeholdersScheduleId: this.scheduleId,
-          projectMemberId: member.projectMemberId,
+          stakeholdersProjectMemberId: member.projectMemberId,
         };
         console.log('requestBody :', requestBody)
-        const response = await defaultInstance.post('/stakeholders/create', {
-          data: requestBody,
-        });
+        const response = await defaultInstance.post('/stakeholders/create', requestBody);
+        console.log('response :', response);
         if (!(response.status >= 200 && response.status < 300)) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
         this.stakeholders.push(
             {
-              id: response.data.result.createStakeholders.stakeholdersId,
+              id: response.data.result.createStakeholder.stakeholdersId,
               type: 10402,    // 모두 담당자로 추가
               roleId: member.roleId,
               name: member.name,

--- a/src/components/MaterialSchedule.vue
+++ b/src/components/MaterialSchedule.vue
@@ -266,6 +266,11 @@
               </td>
             </tr>
             </tbody>
+            <tbody v-else>
+            <tr>
+              <td colspan="5">등록된 이해관계자가 존재하지 않습니다.</td>
+            </tr>
+            </tbody>
           </table>
 
           <!-- 수정 -->
@@ -531,22 +536,22 @@ export default {
   data() {
     return {
       schedule: {
-        id: null,
-        title: '',
-        content: '',
-        startDate: '',
-        endDate: '',
-        priority: null,
-        progress: null,
-        status: null,
-        manHours: null,
-        parentId: '',
-        parentTitle: '',
-        precedingId: '',
-        precedingTitle: '',
-        createdDate: '',
-        modifiedDate: '',
-        projectName: '',
+        // id: null,
+        // title: '',
+        // content: '',
+        // startDate: '',
+        // endDate: '',
+        // priority: null,
+        // progress: null,
+        // status: null,
+        // manHours: null,
+        // parentId: '',
+        // parentTitle: '',
+        // precedingId: '',
+        // precedingTitle: '',
+        // createdDate: '',
+        // modifiedDate: '',
+        // projectName: '',
       },
       searchSchedules: [
         // {
@@ -577,20 +582,19 @@ export default {
       requirements: [],
       searchRequirements: [],
       projectMember: [],
+      searchProjectMemberResults: [],
+      reason: '',     // 수정 사유
       statusItems: [10301, 10302, 10303],
       isSearchModal: false,
       searchScheduleType: '',
       searchScheduleTitleValue: '',
-      selectedScheduleRequestBody: {
-
-      },
+      selectedScheduleRequestBody: {},
 
       // 수정 상태값
       isScheduleEditing: false,
       isTaskEditing: false,
       isStakeholdersEditing: false,
       isScheduleRequirementsEditing: false,
-      reason: '',     // 수정 사유
       newTaskTitle: '',
       newPermission: {name: '', id: '', role_name: ''},
       editingPermissionIndex: null,
@@ -603,7 +607,6 @@ export default {
       isRequirementSearchModal: false,
       searchQuery: '',
       searchProjectMemberState: false,
-      searchProjectMemberResults: [],
       loadingState: true,
       projectTitle: store.getters.projectTitle,
       projectMemberRoleId: store.getters.roleId,
@@ -613,6 +616,7 @@ export default {
   },
   watch: {
     async isOpen() {
+      await this.initDataBeforeGet();
       this.scheduleId = this.modalUrl.split('/').pop();
       await this.getScheduleData();
       this.setSelectedScheduleRequestBody();
@@ -649,6 +653,19 @@ export default {
     },
   },
   methods: {
+    initDataBeforeGet() {
+      this.schedule = {};
+      this.searchSchedules = [];
+      this.tasks = [];
+      this.stakeholders = [];
+      this.newStakeholders = [];
+      this.history = [];
+      this.requirements = [];
+      this.searchRequirements = [];
+      this.projectMember = [];
+      this.searchProjectMemberResults = [];
+      this.reason = '';
+    },
     initSettingValues() {
       this.loadingState = false;
       this.isScheduleEditing = false;
@@ -704,7 +721,7 @@ export default {
         }
       }
     },
-    setSelectedScheduleRequestBody(){
+    setSelectedScheduleRequestBody() {
       this.selectedScheduleRequestBody = {
         scheduleId: this.scheduleId,
         scheduleParentScheduleId: this.schedule.parentId,
@@ -981,12 +998,12 @@ export default {
 
     async getScheduleTitle(scheduleId) {
       try {
-        const response = await defaultInstance.get('/schedules/get/title/'+scheduleId);
+        const response = await defaultInstance.get('/schedules/get/title/' + scheduleId);
         if (!(response.status >= 200 && response.status < 300)) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
         const title = response.data.result.scheduleTitle;
-        console.log('제목 조회 ', title ,'되었습니다.');
+        console.log('제목 조회 ', title, '되었습니다.');
         return title
       } catch (error) {
         console.error('error :', error);

--- a/src/views/CreateSchedule.vue
+++ b/src/views/CreateSchedule.vue
@@ -673,6 +673,10 @@ export default {
           || this.schedule.content.trim() === '') {
         this.toast.error('* 표시된 항목을 채워주세요.');
       } else {
+        if ( this.schedule.startDate  > this.schedule.endDate){
+          this.toast.error('시작일이 종료일보다 늦습니다.');
+          return;
+        }
         this.saveAll();
       }
     },
@@ -703,9 +707,10 @@ export default {
         await router.push({name: '일정'});
       // }
     },
-    openSearchScheduleModal(type) {
+    async openSearchScheduleModal(type) {
       this.isSearchModal = true;
       this.searchScheduleType = type;
+      await this.searchSchedule();
     },
 
     // 부모 일정 검색

--- a/src/views/CreateSchedule.vue
+++ b/src/views/CreateSchedule.vue
@@ -323,7 +323,7 @@
                             <th>내용</th>
                           </tr>
                           </thead>
-                          <tbody>
+                          <tbody v-if="searchSchedules.length > 0">
                           <tr v-for="(schedule, id) in searchSchedules" :key="id">
                             <td>{{ schedule.id }}</td>
                             <td>{{ schedule.title }}</td>
@@ -332,6 +332,11 @@
                               <material-button variant="fill" color="info" @click="selectSchedule(schedule)">선택
                               </material-button>
                             </td>
+                          </tr>
+                          </tbody>
+                          <tbody v-else>
+                          <tr>
+                            <td colspan="3">검색 결과가 없습니다.</td>
                           </tr>
                           </tbody>
                         </table>
@@ -705,19 +710,33 @@ export default {
 
     // 부모 일정 검색
     async searchSchedule() {
-      try {
-        const response = await defaultInstance.get(`/schedules/search/${this.searchScheduleTitleValue}/${this.projectId}`);
-        const data = response.data.result.searchScheduleByTitle;
-        this.searchSchedules = data.map(schedule => ({
-          id: schedule.scheduleId,
-          title: schedule.scheduleTitle,
-          content: schedule.scheduleContent,
-          // type: this.searchScheduleType,
-        }));
-      } catch (error) {
-        console.log(error);
+      if (!this.searchScheduleTitleValue) {
+        try {
+          const response = await defaultInstance.get(`/schedules/list/${this.projectId}`);
+          const data = response.data.result.viewScheduleByProject;
+          this.searchSchedules = data.map(schedule => ({
+            id: schedule.scheduleId,
+            title: schedule.scheduleTitle,
+            content: schedule.scheduleContent,
+          }));
+        } catch (error) {
+          console.log(error);
+        }
+      } else {
+        try {
+          const response = await defaultInstance.get(`/schedules/search/${this.searchScheduleTitleValue}/${this.projectId}`);
+          const data = response.data.result.searchScheduleByTitle;
+          this.searchSchedules = data.map(schedule => ({
+            id: schedule.scheduleId,
+            title: schedule.scheduleTitle,
+            content: schedule.scheduleContent,
+          }));
+        } catch (error) {
+          console.log(error);
+        }
       }
     },
+
     selectSchedule(schedule) {
       if (this.searchScheduleType === 'parent') {         // 부모 일정 선택
         this.schedule.parentId = schedule.id;

--- a/src/views/ScheduleSheet.vue
+++ b/src/views/ScheduleSheet.vue
@@ -23,7 +23,7 @@
     <!-- 클릭 안되는 이슈로 바깥으로 배치   -->
     <div v-if="projectId" class="edit-button-container">
       <!--        <button class="create-button" @click="goToCreateSchedulePage({{ store.getters['project/getProjectId'] }})">등록-->
-      <button class="create-button" @click="goToCreateSchedulePage(projectId)">등록
+      <button v-if="projectMembersRoleId == 10601 " class="create-button" @click="goToCreateSchedulePage(projectId)">등록
       </button>
       <!--      일괄 편집 기능 추후 개발 예정-->
       <!--        <button class="edit-button" @click="toggleEditMode">{{ editMode ? '수정 완료' : '수정' }}</button>-->
@@ -79,6 +79,7 @@ export default defineComponent({
     const projectId = store.getters.projectId;
     const employeeId = store.getters.employeeId;
     const projectMemberId = store.getters.projectMemberId;
+    const projectMembersRoleId = ref(store.getters.roleId);
 
     const schedules = ref([]);
     const copySchedules = ref([]);
@@ -91,7 +92,6 @@ export default defineComponent({
 
     const loadingState = ref(true);
 
-    const projectMembersRoleId = ref(store.getters.roleId);
 
     onMounted(async () => {
       await getProjectSchedules();
@@ -484,6 +484,7 @@ export default defineComponent({
       getProjectRequirements,
       projectId,
       employeeId,
+      projectMembersRoleId,
       schedules,
       copySchedules,
       requirementList,

--- a/src/views/ScheduleSheet.vue
+++ b/src/views/ScheduleSheet.vue
@@ -42,7 +42,7 @@
     </div>
     <MaterialSchedule :isOpen="modalOpen" :modalUrl="modalUrl"
                       :requirementList="copyRequirementList" :projectMembers="copyProjectMembers"
-                      @close="modalOpen = false"></MaterialSchedule>
+                      @close="closeScheduleModal"></MaterialSchedule>
     <!--    <StakeholderModal-->
     <!--        :isOpen="stakeholderModalOpen"-->
     <!--        :selectedStakeholders="selectedStakeholders"-->
@@ -240,6 +240,11 @@ export default defineComponent({
     const openModal = (url) => {
       modalUrl.value = url;
       modalOpen.value = true;
+    };
+
+    const closeScheduleModal = async () => {
+      modalOpen.value = false;
+      location.reload();
     };
 
     // const openStakeholderModal = (rowIndex, value) => {
@@ -495,6 +500,7 @@ export default defineComponent({
       modalOpen,
       modalUrl,
       openModal,
+      closeScheduleModal,
       // editMode,
       // toggleEditMode,
       stakeholderModalOpen,

--- a/src/views/ScheduleSheet.vue
+++ b/src/views/ScheduleSheet.vue
@@ -116,7 +116,37 @@ export default defineComponent({
         {data: 'scheduleEndDate', type: 'date'},
         {data: 'schedulePriority', type: 'numeric', validator: 'numeric'},
         {data: 'scheduleProgress', type: 'numeric', format: 'd%'},
-        {data: 'scheduleStatus', type: 'dropdown', source: ['준비', '진행', '완료']},
+        {
+          data: 'scheduleStatus',
+          type: 'dropdown',
+          source: ['준비', '진행', '완료'],
+          renderer: function(instance, td, row, col, prop, value) {
+            // 원을 표시할 span 요소를 생성합니다.
+            var span = document.createElement('span');
+
+            // 셀의 값에 따라 원의 색상을 결정합니다.
+            switch (value) {
+              case '준비':
+                span.className = 'status-circle status-pending';
+                break;
+              case '진행':
+                span.className = 'status-circle status-in-progress';
+                break;
+              case '완료':
+                span.className = 'status-circle status-completed';
+                break;
+            }
+
+            // 셀의 내용을 완전히 비웁니다.
+            td.innerHTML = '';
+
+            // 원을 셀에 추가합니다.
+            td.appendChild(span);
+
+            // 셀의 값도 표시합니다.
+            td.appendChild(document.createTextNode(' ' + value));
+          }
+        },
         {data: 'scheduleManHours', type: 'numeric'},
         {
           data: 'scheduleEmployeeInfoList', type: 'text', renderer(instance, td, row, col, prop, value) {
@@ -242,7 +272,7 @@ export default defineComponent({
       modalOpen.value = true;
     };
 
-    const closeScheduleModal = async () => {
+    const closeScheduleModal = () => {
       modalOpen.value = false;
       location.reload();
     };
@@ -649,5 +679,24 @@ table.htCore {
   color: #868e96;
   width: 90%;
   height: 80vh;
+}
+
+.status-circle {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.status-in-progress {
+  background-color: #f0ad4e; /* 진행중 상태의 색상 */
+}
+
+.status-completed {
+  background-color: #5cb85c; /* 완료 상태의 색상 */
+}
+
+.status-pending {
+  background-color: #d9534f; /* 보류중 상태의 색상 */
 }
 </style>

--- a/src/views/ScheduleSheet.vue
+++ b/src/views/ScheduleSheet.vue
@@ -114,9 +114,24 @@ export default defineComponent({
         },
         {data: 'scheduleStartDate', type: 'date'},
         {data: 'scheduleEndDate', type: 'date'},
-        {data: 'schedulePriority', type: 'numeric', validator: 'numeric'},
-        {data: 'scheduleProgress', type: 'numeric', format: 'd%'},
         {
+          data: 'schedulePriority',
+          type: 'numeric',
+          renderer: function(instance, td, row, col, prop, value) {
+            if (value === null || value === undefined || value === '') {
+              td.innerText = '-'; // 셀의 값이 비어있는 경우 '-'를 표시
+            } else {
+              td.innerText = value;
+            }
+          }
+        },
+        {
+          data: 'scheduleProgress',
+          type: 'numeric',
+          renderer: function(instance, td, row, col, prop, value) {
+            td.innerText = value + '%'; // 셀의 값 뒤에 '%'를 추가
+          }
+        },        {
           data: 'scheduleStatus',
           type: 'dropdown',
           source: ['준비', '진행', '완료'],
@@ -299,7 +314,8 @@ export default defineComponent({
     };
 
     const formatDate = (date) => {
-      return format(new Date(date[0], date[1] - 1, date[2]), 'dd/MM/yyyy');
+      // return format(new Date(date[0], date[1] - 1, date[2]), 'dd/MM/yyyy');
+      return format(new Date(date[0], date[1] - 1, date[2]), 'yyyy-MM-dd');
     };
 
     const formatChildrenAttributes = (children) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- OmokNoonE/PPM-backend/issues/208

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

#### 일정 상세
- [x] 부모, 선행 일정 검색 시, 검색어가 비어있을 경우 해당 프로젝트의 일정 전체 조회
- [x] 이해관계자 추가 안되는 오류 수정
- [x] 이해관계자 삭제 오류 수정
  - ❗ 테스트 환경에서 원활히 되었으므로, 체크. 실제 배포 환경에서 확인 필요
- [x] 업무 조회 시, 업무, 요구사항 배열 초기화 (ex. 일정의 업무가 없는 경우, 과거 조회한 일정의 업무가 조회되는 현상)
- [x] 일정 등록 시, 시작일, 종료일 날짜 범위 오류 수정
- [x] 일정 등록 버튼, PM만 보이도록 설정
- [x] 일정 동작 진행 후, 모달 닫힌 후, 요청 진행 후 페이지 새로고침 (데이터 갱신을 위함)
- [x] 일정 상태에 따라 일정 시트 및 일정 상세에서 상태에 따른 색상 추가



### 📷스크린샷 (선택)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


- 커밋에 자세한 작업 내용을 기록해두었으니, 참고 부탁드립니다.
- 일정 상세 모달을 닫는 경우, location.reload()로 새로고침하였는데, 사용성에 대해서 추후 리펙토링을 하면 좋을듯 합니다. 어떻게 생각하시는지 추후 의견 부탁드립니다.
