### PR TITLE
[PR] 일정 달력 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.10",
+    "@fullcalendar/daygrid": "^6.1.10",
+    "@fullcalendar/interaction": "^6.1.10",
+    "@fullcalendar/timegrid": "^6.1.10",
+    "@fullcalendar/vue3": "^6.1.10",
     "@handsontable/vue": "^14.3.0",
     "@handsontable/vue3": "^14.3.0",
     "@popperjs/core": "2.11.8",

--- a/src/event-utils.js
+++ b/src/event-utils.js
@@ -1,0 +1,11 @@
+
+let eventGuid = 0
+// let todayStr = new Date().toISOString().replace(/T.*$/, '') // YYYY-MM-DD of today
+
+export const INITIAL_EVENTS = [
+
+]
+
+export function createEventId() {
+    return String(eventGuid++)
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import Dashboard from "../views/Dashboard.vue";
 import ProjectMember from "../views/ProjectMember.vue";
 import Schedules from "../views/Schedules.vue";
+import Calendar from "@/views/Calendar.vue";
 import Notifications from "../views/Notifications.vue";
 import SignIn from "../views/SignIn.vue";
 import MaterialSchedule from "@/components/MaterialSchedule.vue";
@@ -60,6 +61,11 @@ const routes = [
     path: "/schedules",
     name: "일정",
     component: Schedules,
+  },
+  {
+    path: "/schedules/calendar",
+    name: "Calendar",
+    component: Calendar,
   },
   {
     path: "/schedules/details/:scheduleId",

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -1,3 +1,30 @@
+<template>
+  <div class='demo-app'>
+    <div class='demo-app-main'>
+      <FullCalendar
+          class='demo-app-calendar'
+          :options='calendarOptions'
+      >
+        <template v-slot:eventContent='arg'>
+          <b>{{ arg.timeText }}</b>
+          <i>{{ arg.event.title }}</i>
+        </template>
+      </FullCalendar>
+    </div>
+  </div>
+
+  <MaterialSchedule :isOpen="modalOpen" :modalUrl="modalUrl"
+                    :requirementList="copyRequirementList" :projectMembers="copyProjectMembers"
+                    @close="modalOpen = false"></MaterialSchedule>
+
+
+  <div v-if="projectId" class="edit-button-container">
+    <button class="create-button" @click="goToSheetSchedulePage(projectId)">📑 시트로 보기</button>
+  </div>
+
+</template>
+
+
 <script>
 import {defineComponent, onMounted, watch} from 'vue'
 import FullCalendar from '@fullcalendar/vue3'
@@ -137,7 +164,11 @@ const getSchedules = async () => {
       }
     };
 
-    return {schedules, openModal, modalOpen, modalUrl, copyRequirementList, copyProjectMembers};
+    const goToSheetSchedulePage = (projectId) => {
+      router.push({name: '일정', params: {projectId: projectId}});
+    }
+
+    return {projectId, employeeId, schedules, openModal, modalOpen, modalUrl, copyRequirementList, copyProjectMembers, goToSheetSchedulePage};
 
   },
   data() {
@@ -219,29 +250,15 @@ const getSchedules = async () => {
 
 </script>
 
-<template>
-  <div class='demo-app'>
-    <div class='demo-app-main'>
-      <FullCalendar
-          class='demo-app-calendar'
-          :options='calendarOptions'
-      >
-        <template v-slot:eventContent='arg'>
-          <b>{{ arg.timeText }}</b>
-          <i>{{ arg.event.title }}</i>
-        </template>
-      </FullCalendar>
-    </div>
-  </div>
 
-  <MaterialSchedule :isOpen="modalOpen" :modalUrl="modalUrl"
-                    :requirementList="copyRequirementList" :projectMembers="copyProjectMembers"
-                    @close="modalOpen = false"></MaterialSchedule>
-
-
-</template>
 
 <style lang='css'>
+
+.edit-button-container {
+  position: fixed;
+  bottom: 30px;
+  right: 120px;
+}
 
 h2 {
   margin: 0;

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -1,0 +1,267 @@
+<script>
+import {defineComponent, watch} from 'vue'
+import FullCalendar from '@fullcalendar/vue3'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+// import {createEventId, /*INITIAL_EVENTS*/} from "@/event-utils";
+import store from "@/store";
+import { ref } from 'vue';
+import {defaultInstance} from "@/axios/axios-instance";
+import router from "@/router";
+import MaterialSchedule from "@/components/MaterialSchedule.vue";
+
+
+export default defineComponent({
+  components: {
+    MaterialSchedule,
+    FullCalendar,
+  },
+  setup(){
+    const projectId = store.getters.projectId;
+    const schedules = ref([]);
+
+    const modalOpen = ref(false);
+    const modalUrl = ref('');
+
+    const copyRequirementList = ref([]);
+    const copyProjectMembers = ref([]);
+    const openModal = (url) => {
+      console.log("openModal called with url: ", url); // 추가
+      modalUrl.value = url;
+      modalOpen.value = true;
+    };
+
+
+    defaultInstance.get(`schedules/list/${projectId}`)
+    .then(response => {
+      const schedulesData = response.data.result.viewScheduleByProject;
+      schedules.value = schedulesData.map(schedule => {
+        let color;
+        switch (schedule.scheduleStatus) {
+          case '10301':
+            color = '#ffba26';
+            break;
+          case '10302':
+            color = '#24a8ef';
+            break;
+          case '10303':
+            color = '#61cc39';
+            break;
+          default:
+            color = 'gray';
+        }
+        return {
+          id: schedule.scheduleId,
+          title: schedule.scheduleTitle,
+          start: new Date(...schedule.scheduleStartDate).toISOString().split('T')[0],
+          end: new Date(...schedule.scheduleEndDate).toISOString().split('T')[0],
+          backgroundColor: color,
+          textColor: 'black',
+          // 추가적인 사용자 정의 속성
+          scheduleId: schedule.scheduleId,
+        };
+      });
+      console.log(schedules.value);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+
+    return { schedules, openModal, modalOpen, modalUrl, copyRequirementList, copyProjectMembers };
+
+  },
+  data() {
+    return {
+      calendarOptions: {
+        plugins: [
+          dayGridPlugin,
+          timeGridPlugin,
+          interactionPlugin // needed for dateClick
+        ],
+        headerToolbar: {
+          left: 'prev,next today',
+          center: 'title',
+          right: 'dayGridMonth,timeGridWeek,timeGridDay'
+        },
+        initialView: 'dayGridMonth',
+        initialEvents: [], // alternatively, use the `events` setting to fetch from a feed
+        editable: true,
+        selectable: true,
+        selectMirror: true,
+        dayMaxEvents: true,
+        weekends: true, // weekends are always enabled
+        select: this.handleDateSelect,
+        eventClick: this.handleEventClick,
+        eventsSet: this.handleEvents
+        /* you can update a remote database when these fire:
+        eventAdd:
+        eventChange:
+        eventRemove:
+        */
+      },
+      currentEvents: [],
+    }
+  },
+  // schedules가 변경될 때마다 calendarOptions의 events를 업데이트합니다.
+  created () {
+    watch(() => this.schedules, (newSchedules) => {
+      this.calendarOptions.events = newSchedules;
+    }, { immediate: true }); // immediate 옵션을 true로 설정하여 초기에 한 번 실행합니다.
+  },
+  async mounted() {
+    await this.getProjectMembers();
+    await this.getRequirementList();
+  },
+  methods: {
+
+    async getRequirementList() {
+      // 요구사항 목록 조회 로직 구현
+      try {
+        const response = await defaultInstance.get(`/requirements/list/${this.projectId}`);
+        const requirementList = response.data.result.viewRequirementsList.projectRequirementsList;
+        for (let i = 0; i < requirementList.length; i++) {
+          const requirementId = requirementList[i].requirementsId;
+          const requirementName = requirementList[i].requirementsName;
+          const requirementContent = requirementList[i].requirementsContent;
+
+          this.copyRequirementList.value[i] = {
+            requirementId: requirementId,
+            requirementName: requirementName,
+            requirementContent: requirementContent,
+          };
+        }
+
+        console.log('requirementList :', requirementList);
+        console.log('copyRequirementList :', this.copyRequirementList);
+      } catch (error) {
+        console.log(error);
+      }
+    },
+
+    async getProjectMembers () {
+      try {
+        /* 실질적인 API 주소 확인해야함. Controller 메소드 확인 */
+        const response = await defaultInstance.get(`projectMembers/list/${this.projectId}`);
+        const projectMembers = response.data.result.viewProjectMembersByProject;
+        for (let i = 0; i < projectMembers.length; i++) {
+          const employeeName = projectMembers[i].employeeName;
+          const projectMemberEmployeeId = projectMembers[i].projectMemberEmployeeId;      // TODO. projectId로 구성원 조회할때 같이 받아오도록 수정 요청
+          const projectMemberId = projectMembers[i].projectMemberId;                      // TODO. projectId로 구성원 조회할때 같이 받아오도록 수정 요청
+          const projectMemberRoleName = projectMembers[i].projectMemberRoleName;
+
+          this.copyProjectMembers.value[i] = {
+            name: employeeName,
+            employeeId: projectMemberEmployeeId,
+            projectMemberId: projectMemberId,
+            roleName: projectMemberRoleName,
+            isChecked: false, // 체크박스에 활용될 Value 추가
+          };
+        }
+        console.log('copySchedule.value : ', this.copyProjectMembers.value);
+
+      } catch (error) {
+        console.error(error);
+      }
+    },
+
+    handleDateSelect(selectInfo) {
+      // let title = prompt('Please enter a new title for your event')
+      // let calendarApi = selectInfo.view.calendar
+      //
+      // calendarApi.unselect() // clear date selection
+      //
+      // if (title) {
+      //   calendarApi.addEvent({
+      //     id: createEventId(),
+      //     title,
+      //     start: selectInfo.startStr,
+      //     end: selectInfo.endStr,
+      //     allDay: selectInfo.allDay
+      //   })
+      // }
+
+      // 날짜 칸 클릭시 스케줄 생성 페이지로 이동
+      const projectId = store.getters.projectId;
+      const startDate = selectInfo.startStr;
+
+      // 클릭한 날짜를 자동으로 startDate로 등록하는 기능을 위해 parameter로 startDate 추가
+      router.push({name: 'CreateSchedule', params: {projectId: projectId}, query: {startDate: startDate}});
+
+    },
+    handleEventClick(clickInfo) {
+
+
+      let scheduleId = clickInfo.event.extendedProps.scheduleId;
+      this.openModal(`http://localhost/schedule/details/${scheduleId}`)
+
+    },
+    handleEvents(events) {
+      this.currentEvents = events
+    },
+  }
+})
+
+</script>
+
+<template>
+  <div class='demo-app'>
+    <div class='demo-app-main'>
+      <FullCalendar
+          class='demo-app-calendar'
+          :options='calendarOptions'
+      >
+        <template v-slot:eventContent='arg'>
+          <b>{{ arg.timeText }}</b>
+          <i>{{ arg.event.title }}</i>
+        </template>
+      </FullCalendar>
+    </div>
+  </div>
+
+  <MaterialSchedule :isOpen="modalOpen" :modalUrl="modalUrl"
+                    :requirementList="copyRequirementList" :projectMembers="copyProjectMembers"
+                    @close="modalOpen = false"></MaterialSchedule>
+
+
+</template>
+
+<style lang='css'>
+
+h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+ul {
+  margin: 0;
+  padding: 0 0 0 1.5em;
+}
+
+li {
+  margin: 1.5em 0;
+  padding: 0;
+}
+
+b { /* used for event dates/times */
+  margin-right: 3px;
+}
+
+.demo-app {
+  display: flex;
+  min-height: 100%;
+  font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+  font-size: 14px;
+}
+
+.demo-app-main {
+  flex-grow: 1;
+  padding: 3em;
+}
+
+.fc { /* the calendar root */
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+</style>

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -1,12 +1,12 @@
 <script>
-import {defineComponent, watch} from 'vue'
+import {defineComponent, onMounted, watch} from 'vue'
 import FullCalendar from '@fullcalendar/vue3'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import interactionPlugin from '@fullcalendar/interaction'
 // import {createEventId, /*INITIAL_EVENTS*/} from "@/event-utils";
 import store from "@/store";
-import { ref } from 'vue';
+import {ref} from 'vue';
 import {defaultInstance} from "@/axios/axios-instance";
 import router from "@/router";
 import MaterialSchedule from "@/components/MaterialSchedule.vue";
@@ -17,9 +17,11 @@ export default defineComponent({
     MaterialSchedule,
     FullCalendar,
   },
-  setup(){
+  setup() {
     const projectId = store.getters.projectId;
     const schedules = ref([]);
+    const requirementList = ref([]);
+    const projectMembers = ref([]);
 
     const modalOpen = ref(false);
     const modalUrl = ref('');
@@ -32,43 +34,100 @@ export default defineComponent({
       modalOpen.value = true;
     };
 
-
-    defaultInstance.get(`schedules/list/${projectId}`)
-    .then(response => {
-      const schedulesData = response.data.result.viewScheduleByProject;
-      schedules.value = schedulesData.map(schedule => {
-        let color;
-        switch (schedule.scheduleStatus) {
-          case '10301':
-            color = '#ffba26';
-            break;
-          case '10302':
-            color = '#24a8ef';
-            break;
-          case '10303':
-            color = '#61cc39';
-            break;
-          default:
-            color = 'gray';
-        }
-        return {
-          id: schedule.scheduleId,
-          title: schedule.scheduleTitle,
-          start: new Date(...schedule.scheduleStartDate).toISOString().split('T')[0],
-          end: new Date(...schedule.scheduleEndDate).toISOString().split('T')[0],
-          backgroundColor: color,
-          textColor: 'black',
-          // 추가적인 사용자 정의 속성
-          scheduleId: schedule.scheduleId,
-        };
-      });
-      console.log(schedules.value);
-    })
-    .catch(error => {
-      console.error(error);
+    onMounted(async () => {
+      await getSchedules();
+      await getProjectRequirements();
+      await getProjectMembers();
     });
 
-    return { schedules, openModal, modalOpen, modalUrl, copyRequirementList, copyProjectMembers };
+    const getSchedules = async () => {
+      await defaultInstance.get(`schedules/list/${projectId}`)
+          .then(response => {
+            const schedulesData = response.data.result.viewScheduleByProject;
+            schedules.value = schedulesData.map(schedule => {
+              let color;
+              switch (schedule.scheduleStatus) {
+                case '10301':
+                  color = '#ffba26';
+                  break;
+                case '10302':
+                  color = '#24a8ef';
+                  break;
+                case '10303':
+                  color = '#61cc39';
+                  break;
+                default:
+                  color = 'gray';
+              }
+              return {
+                id: schedule.scheduleId,
+                title: schedule.scheduleTitle,
+                start: new Date(...schedule.scheduleStartDate).toISOString().split('T')[0],
+                end: new Date(...schedule.scheduleEndDate).toISOString().split('T')[0],
+                backgroundColor: color,
+                textColor: 'black',
+                // 추가적인 사용자 정의 속성
+                scheduleId: schedule.scheduleId,
+              };
+            });
+            console.log(schedules.value);
+          })
+          .catch(error => {
+            console.error(error);
+          });
+    }
+
+    const getProjectRequirements = async () => {
+      // 요구사항 목록 조회 로직 구현
+      try {
+        const response = await defaultInstance.get(`/requirements/list/${projectId}`);
+        requirementList.value = response.data.result.viewRequirementsList.projectRequirementsList;
+        for (let i = 0; i < requirementList.value.length; i++) {
+          const requirementId = requirementList.value[i].requirementsId;
+          const requirementName = requirementList.value[i].requirementsName;
+          const requirementContent = requirementList.value[i].requirementsContent;
+
+          copyRequirementList.value[i] = {
+            requirementId: requirementId,
+            requirementName: requirementName,
+            requirementContent: requirementContent,
+          };
+        }
+
+        console.log('requirementList :', requirementList);
+        console.log('copyRequirementList :', copyRequirementList);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    const getProjectMembers = async () => {
+      try {
+        /* 실질적인 API 주소 확인해야함. Controller 메소드 확인 */
+        const response = await defaultInstance.get(`projectMembers/list/${projectId}`);
+        projectMembers.value = response.data.result.viewProjectMembersByProject;
+        for (let i = 0; i < projectMembers.value.length; i++) {
+          const employeeName = projectMembers.value[i].employeeName;
+          const projectMemberEmployeeId = projectMembers.value[i].projectMemberEmployeeId;      // TODO. projectId로 구성원 조회할때 같이 받아오도록 수정 요청
+          const projectMemberId = projectMembers.value[i].projectMemberId;                      // TODO. projectId로 구성원 조회할때 같이 받아오도록 수정 요청
+          const projectMemberRoleName = projectMembers.value[i].projectMemberRoleName;
+
+          copyProjectMembers.value[i] = {
+            name: employeeName,
+            employeeId: projectMemberEmployeeId,
+            projectMemberId: projectMemberId,
+            roleName: projectMemberRoleName,
+            isChecked: false, // 체크박스에 활용될 Value 추가
+          };
+        }
+        console.log('copySchedule.value : ', copyProjectMembers.value);
+
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    return {schedules, openModal, modalOpen, modalUrl, copyRequirementList, copyProjectMembers};
 
   },
   data() {
@@ -104,67 +163,13 @@ export default defineComponent({
     }
   },
   // schedules가 변경될 때마다 calendarOptions의 events를 업데이트합니다.
-  created () {
+  created() {
     watch(() => this.schedules, (newSchedules) => {
       this.calendarOptions.events = newSchedules;
-    }, { immediate: true }); // immediate 옵션을 true로 설정하여 초기에 한 번 실행합니다.
+    }, {immediate: true}); // immediate 옵션을 true로 설정하여 초기에 한 번 실행합니다.
   },
-  async mounted() {
-    await this.getProjectMembers();
-    await this.getRequirementList();
-  },
+
   methods: {
-
-    async getRequirementList() {
-      // 요구사항 목록 조회 로직 구현
-      try {
-        const response = await defaultInstance.get(`/requirements/list/${this.projectId}`);
-        const requirementList = response.data.result.viewRequirementsList.projectRequirementsList;
-        for (let i = 0; i < requirementList.length; i++) {
-          const requirementId = requirementList[i].requirementsId;
-          const requirementName = requirementList[i].requirementsName;
-          const requirementContent = requirementList[i].requirementsContent;
-
-          this.copyRequirementList.value[i] = {
-            requirementId: requirementId,
-            requirementName: requirementName,
-            requirementContent: requirementContent,
-          };
-        }
-
-        console.log('requirementList :', requirementList);
-        console.log('copyRequirementList :', this.copyRequirementList);
-      } catch (error) {
-        console.log(error);
-      }
-    },
-
-    async getProjectMembers () {
-      try {
-        /* 실질적인 API 주소 확인해야함. Controller 메소드 확인 */
-        const response = await defaultInstance.get(`projectMembers/list/${this.projectId}`);
-        const projectMembers = response.data.result.viewProjectMembersByProject;
-        for (let i = 0; i < projectMembers.length; i++) {
-          const employeeName = projectMembers[i].employeeName;
-          const projectMemberEmployeeId = projectMembers[i].projectMemberEmployeeId;      // TODO. projectId로 구성원 조회할때 같이 받아오도록 수정 요청
-          const projectMemberId = projectMembers[i].projectMemberId;                      // TODO. projectId로 구성원 조회할때 같이 받아오도록 수정 요청
-          const projectMemberRoleName = projectMembers[i].projectMemberRoleName;
-
-          this.copyProjectMembers.value[i] = {
-            name: employeeName,
-            employeeId: projectMemberEmployeeId,
-            projectMemberId: projectMemberId,
-            roleName: projectMemberRoleName,
-            isChecked: false, // 체크박스에 활용될 Value 추가
-          };
-        }
-        console.log('copySchedule.value : ', this.copyProjectMembers.value);
-
-      } catch (error) {
-        console.error(error);
-      }
-    },
-
     handleDateSelect(selectInfo) {
       // let title = prompt('Please enter a new title for your event')
       // let calendarApi = selectInfo.view.calendar

--- a/src/views/CreateSchedule.vue
+++ b/src/views/CreateSchedule.vue
@@ -371,7 +371,7 @@ export default {
       schedule: {
         title: '',
         content: '',
-        startDate: '',
+        startDate: this.$route.query.startDate,
         endDate: '',
         priority: null,
         manHours: null,

--- a/src/views/ScheduleSheet.vue
+++ b/src/views/ScheduleSheet.vue
@@ -30,6 +30,15 @@
       <!--        <button @click="checkCopySchedules">CopySchedules 값 확인</button>-->
     </div>
 
+    <div v-if="projectId" class="edit-button-container2">
+      <!--        <button class="create-button" @click="goToCreateSchedulePage({{ store.getters['project/getProjectId'] }})">등록-->
+      <button class="create-button" @click="goToCalendarPage(projectId)">🗓️️ 달력으로 보기
+      </button>
+      <!--      일괄 편집 기능 추후 개발 예정-->
+      <!--        <button class="edit-button" @click="toggleEditMode">{{ editMode ? '수정 완료' : '수정' }}</button>-->
+      <!--        <button @click="checkCopySchedules">CopySchedules 값 확인</button>-->
+    </div>
+
     <div class="delete-reason" v-if="showDeleteModal">
       <div class="delete-reason-content">
         <h5>삭제 사유</h5>
@@ -358,6 +367,11 @@ export default defineComponent({
       router.push({name: 'CreateSchedule', params: {projectId: projectId}});
     }
 
+    const goToCalendarPage = (projectId) => {
+      // router를 활용하여 페이지 이동
+      router.push({name: 'Calendar', params: {projectId: projectId}});
+    }
+
     const getProjectSchedules = async () => {
       try {
         // const employeeId = store.getters['auth/getEmployeeId'];  // 로그인한 사용자의 ID, 향후 이 코드로 바꿔야함.
@@ -508,6 +522,7 @@ export default defineComponent({
       deleteSchedule,
       confirmDelete,
       goToCreateSchedulePage,
+      goToCalendarPage,
       showDeleteModal,
       deleteReason,
       deleteId,
@@ -600,6 +615,13 @@ table.htCore {
   position: fixed;
   bottom: 30px;
   right: 120px;
+}
+
+.edit-button-container2
+{
+  position: fixed;
+  bottom: 30px;
+  right: 220px;
 }
 
 .create-button {


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #63 

## 📝작업 내용

> 1. fullCalendar를 이용하여 일정을 달력 형태로 확인할 수 있는 페이지 구현, 일정의 상태(준비, 진행, 완료)에 따라 색상 표시
> 2. 시트로 보기 ↔︎ 달력으로 보기 버튼 추가
> 3. 달력에서 날짜를 클릭했을 때, 해당 날짜를 startDate로 하여 일정 등록 페이지로 이동함
> 4. 달력에서 일정을 클릭했을 때, 해당 일정의 상세보기 모달 띄워짐


### 📷스크린샷 (선택)
<img width="1485" alt="image" src="https://github.com/OmokNoonE/PPM-frontend/assets/80697609/b76f7849-fada-475d-8e17-e6541b7274bd">



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
