### PR TITLE
[PR] 일정 페이지 UI 피드백 반영

### DIFF
--- a/src/components/MaterialInput.vue
+++ b/src/components/MaterialInput.vue
@@ -14,6 +14,8 @@
       :placeholder="placeholder"
       :isRequired="isRequired"
       :disabled="disabled"
+      :min="min"
+      :max="max"
       @input="$emit('update:modelValue', $event.target.value)"
     />
   </div>
@@ -72,6 +74,14 @@ export default {
     isRequired: {
       type: Boolean,
       default: false,
+    },
+    min: {
+      type: String,
+      default: "",
+    },
+    max: {
+      type: String,
+      default: "",
     },
   },
   emits: ["update:modelValue"],

--- a/src/components/MaterialSchedule.vue
+++ b/src/components/MaterialSchedule.vue
@@ -77,7 +77,7 @@
             <div class="modal-info-item">
               <span class="modal-info-label">가중치:</span>
               <div v-if="isScheduleEditing">
-                <MaterialInput id="weight" type="number" label="가중치를 입력하세요."
+                <MaterialInput id="weight" type="number" min="1" max="100" label="가중치"
                                v-model="schedule.priority"></MaterialInput>
               </div>
               <span v-else class="modal-info-value">{{ schedule.priority }}</span>

--- a/src/components/MaterialSchedule.vue
+++ b/src/components/MaterialSchedule.vue
@@ -199,7 +199,16 @@
                 </MaterialButton>
               </td>
             </tr>
-            <tr v-if="checkRoleId">
+            </tbody>
+            <tbody v-else-if="!isTaskEditing&tasks.length > 0">
+            <tr v-for="task in tasks" :key="task.id">
+              <td class="task-title">{{ task.title }}</td>
+              <td class="task-isCompleted">
+                <input type="checkbox" :checked="task.isCompleted" disabled>
+                <label>{{ task.isCompleted ? '완료' : '미완료' }}</label>
+              </td>
+            </tr>
+<!--            <tr v-if="checkRoleId">
               <td class="task-title" style="width: 80%">
                 <MaterialInput type="text" label="새 업무명을 입력하세요." v-model="newTaskTitle"></MaterialInput>
               </td>
@@ -212,16 +221,7 @@
               <td>
                 <MaterialButton class="custom-button" style="width: 100px" @click="addTask">추가</MaterialButton>
               </td>
-            </tr>
-            </tbody>
-            <tbody v-else-if="!isTaskEditing&tasks.length > 0">
-            <tr v-for="task in tasks" :key="task.id">
-              <td class="task-title">{{ task.title }}</td>
-              <td class="task-isCompleted">
-                <input type="checkbox" :checked="task.isCompleted" disabled>
-                <label>{{ task.isCompleted ? '완료' : '미완료' }}</label>
-              </td>
-            </tr>
+            </tr>-->
             </tbody>
             <tbody v-else>
             <tr>
@@ -230,10 +230,17 @@
             </tbody>
           </table>
 
-
           <!-- 수정 -->
-          <div class="modal-actions">
-            <MaterialButton v-if="!isTaskEditing" class="modal-action-button" @click="isTaskEditing = true">수정
+          <div class="modal-actions-bottom">
+            <MaterialInput class="w-50" type="text" label="새 업무명을 입력하세요." v-model="newTaskTitle" id="taskTitle"></MaterialInput>
+            <div class="task-isCompleted" style="flex: 0 0 100px">
+              <input style="width: 13px" disabled="true" type="checkbox">
+              <label style="width: 42px">미완료</label>
+            </div>
+            <div class="task-add" style="flex: 0 0 100px">
+              <MaterialButton class="custom-button" @click="addTask">추가</MaterialButton>
+            </div>
+            <MaterialButton v-if="!isTaskEditing" class="modal-action-button" @click="isTaskEditing = true" style="left: 10%">수정
             </MaterialButton>
             <div v-else>
               <MaterialButton class="modal-action-button delete-button" @click="isTaskEditing = false">완료
@@ -1479,6 +1486,14 @@ export default {
 
 .status-pending {
   background-color: #d9534f; /* 보류중 상태의 색상 */
+}
+
+.modal-actions-bottom {
+  bottom: 10px;
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+  right: 10px;
 }
 
 @keyframes fadeOut {

--- a/src/components/MaterialSchedule.vue
+++ b/src/components/MaterialSchedule.vue
@@ -91,7 +91,7 @@
               <p class="importance">{{ isScheduleEditing ? '*' : '' }}</p>
               <span class="modal-info-label">상태:</span>
               <div v-if="isScheduleEditing">
-                <select id="status" v-model="schedule.status">
+                <select id="status" v-model="schedule.status" @change="selectStatus(schedule.status)">
                   <option v-for="status in statusItems" :key="status" :value="status">
                     {{
                       status === 10303 ? '완료' :
@@ -1129,6 +1129,21 @@ export default {
           .catch(error => {
             console.error(error);
           });
+    },
+    selectStatus(status) {
+      switch (status) {
+        case 10301:
+          this.reason = '준비 상태로 변경';
+          break;
+        case 10302:
+          this.reason = '진행 상태로 변경';
+          break;
+        case 10303:
+          this.reason = '완료 상태로 변경';
+          break;
+        default:
+          this.reason = '';
+      }
     },
   },
 };

--- a/src/views/CreateSchedule.vue
+++ b/src/views/CreateSchedule.vue
@@ -53,9 +53,11 @@
               <!--   가중치  -->
               <div class="modal-info">
                 <div class="modal-info-item">
-                  <span class="modal-info-label">가중치</span>
-                  <MaterialInput id="weight" type="number" label="가중치를 입력하세요.(1 ~ 100)"
-                                 v-model="schedule.priority"></MaterialInput>
+                  <span class="modal-info-label">가중치
+                    <p class="font-weight-light text-xs">(1~100)</p>
+                  </span>
+                  <MaterialInput class="w-15" id="weight" type="number" min="1" max="100"
+                                label="가중치" v-model="schedule.priority"></MaterialInput>
                 </div>
               </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #72 

## 📝작업 내용

- [x] 업무 추가 버튼이 수정 밖으로 나와 있도록
- [x] 일정 상태 변경 시, 자동으로 수정사유 작성 및 저장(일정까지 변동사항 적용)
- [x] 일정 등록 및 수정 시, 가중치 범위 설정

### 📷스크린샷 (선택)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
